### PR TITLE
feat: store/add handler includes method: "PUT" in upload response

### DIFF
--- a/packages/capabilities/src/types.ts
+++ b/packages/capabilities/src/types.ts
@@ -468,6 +468,11 @@ export interface StoreAddSuccessUpload extends StoreAddSuccessResult {
   status: StoreAddSuccessStatusUpload
   url: ToString<URL>
   headers: Record<string, string>
+  /**
+   * http method to use in request to url.
+   * If undefined, try "PUT".
+   */
+  method?: string
 }
 
 export interface StoreRemoveSuccess {

--- a/packages/upload-api/src/store/add.js
+++ b/packages/upload-api/src/store/add.js
@@ -71,7 +71,7 @@ export function storeAddProvider(context) {
       }
     }
 
-    const { url, headers } = await carStoreBucket.createUploadUrl(link, size)
+    const { url, headers, method = 'PUT' } = await carStoreBucket.createUploadUrl(link, size)
     return {
       ok: {
         status: 'upload',
@@ -79,7 +79,7 @@ export function storeAddProvider(context) {
         with: space,
         link,
         url: url.toString(),
-        method: 'PUT',
+        method,
         headers,
       },
     }

--- a/packages/upload-api/src/store/add.js
+++ b/packages/upload-api/src/store/add.js
@@ -79,6 +79,7 @@ export function storeAddProvider(context) {
         with: space,
         link,
         url: url.toString(),
+        method: 'PUT',
         headers,
       },
     }

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -402,6 +402,7 @@ export interface CarStoreBucket {
       'x-amz-checksum-sha256': string
       'content-length': string
     } & Record<string, string>
+    method?: string
   }>
 }
 


### PR DESCRIPTION
Rationale:
* this makes the response better describe to the client the action that needs to be taken. I was [doing this](https://github.com/web3-storage/migrate-to-w3up/pull/3/commits/380c25e39c28534badd814b7927cd5b0632f7ac7#diff-ce8b41637e82da88d0592206f82d41cd876392ff3d2c63a738b07deded27d2c7R99) and had to hardcode PUT after trying POST.
* if server instructs client on method, it increases the amount of upload targets this protocol can serve, not just those accepting PUT requests, but any http method (which in general can be any string)