### PR TITLE
feat!: deprecate issuer

### DIFF
--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -515,7 +515,12 @@ export interface StoreAddInput {
   link: UnknownLink
   size: number
   origin?: UnknownLink
-  issuer: DID
+
+  /**
+   * @deprecated - Issuer of the invocation is irrelevant as long as
+   * they have authorization to invoke on subject `space`.
+   */
+  issuer?: DID
   invocation: UCANLink
 }
 


### PR DESCRIPTION
Per https://github.com/web3-storage/w3up/issues/1339#issuecomment-2015852195 this PR deprecates `issuer` field from table record.