### PR TITLE
feat: remove issuer row

### DIFF
--- a/packages/upload-api/src/store/add.js
+++ b/packages/upload-api/src/store/add.js
@@ -23,7 +23,7 @@ export function storeAddProvider(context) {
     const space = /** @type {import('@ucanto/interface').DIDKey} */ (
       Server.DID.parse(capability.with).did()
     )
-    const issuer = invocation.issuer.did()
+
     const [allocated, carExists] = await Promise.all([
       allocate(
         {
@@ -47,7 +47,6 @@ export function storeAddProvider(context) {
       link,
       size,
       origin,
-      issuer,
       invocation: invocation.cid,
     })
     if (res.error) {

--- a/packages/upload-api/src/types.ts
+++ b/packages/upload-api/src/types.ts
@@ -515,7 +515,12 @@ export interface StoreAddInput {
   link: UnknownLink
   size: number
   origin?: UnknownLink
-  issuer: DID
+
+  /**
+   * @deprecated - Issuer of the invocation is irrelevant as long as
+   * they have authorization to invoke on subject `space`.
+   */
+  issuer?: DID
   invocation: UCANLink
 }
 


### PR DESCRIPTION
This is based on #1344 and it stops passing issuer when inserting into a table. I wanted to make this a separate PR so we can update w3infra first and remove field there and then stop passing here.