### PR TITLE
fix: remove unneeded token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: google-github-actions/release-please-action@v3
         id: release
         with:
-          token: ${{ secrets.GH_TOKEN }}
           command: manifest
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json


### PR DESCRIPTION
We're getting a `Error creating Pull Request: Not Found` aka a 404 which to me signals some auth issue. More [here](https://github.com/w3s-project/w3up/actions/runs/8804910171/job/24166333991).

Other repos such as [content-claims](https://github.com/w3s-project/content-claims/blob/main/.github/workflows/release.yml#L28) don't use this and are working properly.