### PR TITLE
chore: use nodejs 18 in `upload-api` tests

### DIFF
--- a/.github/workflows/upload-api.yml
+++ b/.github/workflows/upload-api.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           registry-url: https://registry.npmjs.org/
           cache: 'pnpm'
 
@@ -67,7 +67,7 @@ jobs:
       - name: Setup
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           registry-url: https://registry.npmjs.org/
           cache: 'pnpm'
 


### PR DESCRIPTION
We switched w3infra to sst v2 and with it upgraded to nodejs 18. We should test on same as infra.