### PR TITLE
feat: use digest in `blob/accept` location commitment

### DIFF
--- a/packages/filecoin-api/package.json
+++ b/packages/filecoin-api/package.json
@@ -159,7 +159,7 @@
     "@ucanto/server": "^10.0.0",
     "@ucanto/transport": "^9.1.1",
     "@web3-storage/capabilities": "workspace:^",
-    "@web3-storage/content-claims": "^4.0.4",
+    "@web3-storage/content-claims": "^5.0.0",
     "@web3-storage/data-segment": "^4.0.0",
     "fr32-sha2-256-trunc254-padded-binary-tree-multihash": "^3.3.0",
     "p-map": "^6.0.0"

--- a/packages/upload-api/package.json
+++ b/packages/upload-api/package.json
@@ -201,7 +201,7 @@
     "@web3-storage/access": "workspace:^",
     "@web3-storage/blob-index": "workspace:^",
     "@web3-storage/capabilities": "workspace:^",
-    "@web3-storage/content-claims": "^4.0.4",
+    "@web3-storage/content-claims": "^5.0.0",
     "@web3-storage/did-mailto": "workspace:^",
     "@web3-storage/filecoin-api": "workspace:^",
     "multiformats": "^12.1.2",

--- a/packages/upload-api/src/blob/accept.js
+++ b/packages/upload-api/src/blob/accept.js
@@ -2,10 +2,8 @@ import * as Server from '@ucanto/server'
 import * as DID from '@ipld/dag-ucan/did'
 import * as W3sBlob from '@web3-storage/capabilities/web3.storage/blob'
 import { Assert } from '@web3-storage/content-claims/capability'
-import { create as createLink } from 'multiformats/link'
 import { Invocation } from '@ucanto/core'
 import * as Digest from 'multiformats/hashes/digest'
-import { code as rawCode } from 'multiformats/codecs/raw'
 import * as API from '../types.js'
 import {
   AllocatedMemoryHadNotBeenWrittenTo,
@@ -40,7 +38,6 @@ export function blobAcceptProvider(context) {
       }
 
       const digest = Digest.decode(blob.digest)
-      const content = createLink(rawCode, digest)
       const createUrl = await context.blobsStorage.createDownloadUrl(
         digest.bytes
       )
@@ -53,7 +50,7 @@ export function blobAcceptProvider(context) {
         audience: DID.parse(space),
         with: context.id.toDIDKey(),
         nb: {
-          content,
+          content: { digest: digest.bytes },
           location: [createUrl.ok],
         },
         expiration: Infinity,

--- a/packages/upload-api/test/handlers/web3.storage.js
+++ b/packages/upload-api/test/handlers/web3.storage.js
@@ -679,7 +679,7 @@ export const test = {
     assert.equal(delegation.capabilities.length, 1)
     assert.ok(delegation.capabilities[0].can, Assert.location.can)
     // @ts-expect-error nb unknown
-    assert.ok(delegation.capabilities[0].nb.content.equals(content))
+    assert.ok(equals(delegation.capabilities[0].nb.content.digest, content.multihash.bytes))
     // @ts-expect-error nb unknown
     const locations = delegation.capabilities[0].nb.location
     assert.equal(locations.length, 1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -304,8 +304,8 @@ importers:
         specifier: workspace:^
         version: link:../capabilities
       '@web3-storage/content-claims':
-        specifier: ^4.0.4
-        version: 4.0.5
+        specifier: ^5.0.0
+        version: 5.0.0
       '@web3-storage/data-segment':
         specifier: ^4.0.0
         version: 4.0.0
@@ -447,8 +447,8 @@ importers:
         specifier: workspace:^
         version: link:../capabilities
       '@web3-storage/content-claims':
-        specifier: ^4.0.4
-        version: 4.0.5
+        specifier: ^5.0.0
+        version: 5.0.0
       '@web3-storage/did-mailto':
         specifier: workspace:^
         version: link:../did-mailto
@@ -4443,15 +4443,15 @@ packages:
       web-streams-polyfill: 3.3.3
     dev: true
 
-  /@web3-storage/content-claims@4.0.5:
-    resolution: {integrity: sha512-+WpCkTN8aRfUCrCm0kOMZad+FRnFymVDFvS6/+PJMPGP17cci1/c5lqYdrjFV+5MkhL+BkUJVtRTx02G31FHmQ==}
+  /@web3-storage/content-claims@5.0.0:
+    resolution: {integrity: sha512-HJFRFsR0qHCe0cOERsb3AjAxxzohYMMoIWaGJgrShDycnl6yqXHrGcdua1BWUDu5pmvKzwD9D7VmI8aSfrCcRA==}
     dependencies:
       '@ucanto/client': 9.0.1
       '@ucanto/interface': 10.0.1
       '@ucanto/server': 10.0.0
       '@ucanto/transport': 9.1.1
-      carstream: 1.1.1
-      multiformats: 12.1.3
+      carstream: 2.1.0
+      multiformats: 13.1.0
     dev: false
 
   /@web3-storage/data-segment@3.2.0:
@@ -5261,14 +5261,6 @@ packages:
       ansicolors: 0.3.2
       redeyed: 2.1.1
     dev: true
-
-  /carstream@1.1.1:
-    resolution: {integrity: sha512-cgn3TqHo6SPsHBTfM5QgXngv6HtwgO1bKCHcdS35vBrweLcYrIG/+UboCbvnIGA0k8NtAYl/DvDdej/9pZGZxQ==}
-    dependencies:
-      '@ipld/dag-cbor': 9.2.0
-      multiformats: 12.1.3
-      uint8arraylist: 2.4.8
-    dev: false
 
   /carstream@2.1.0:
     resolution: {integrity: sha512-4kYIT1Y+GW/+o6wxS2tZlKnnINcgm4ceODBmyoLNaiQ17G2FNmzvUnQnVQkugC4NORTMCzD6KZEMT534XMJ4Yw==}


### PR DESCRIPTION
This upgrades the content-claims dependency, allowing us to use multihash digest in location claim. It brings implementation in line with the spec.