### PR TITLE
fix: export blob client

### DIFF
--- a/packages/w3up-client/src/client.js
+++ b/packages/w3up-client/src/client.js
@@ -30,6 +30,7 @@ import * as Result from './result.js'
 
 export {
   AccessClient,
+  BlobClient,
   FilecoinClient,
   IndexClient,
   PlanClient,


### PR DESCRIPTION
Allows `client.capability.blob` to be typed.